### PR TITLE
Update the dialog style to follow elementary HIG

### DIFF
--- a/src/Widgets/UI.vala
+++ b/src/Widgets/UI.vala
@@ -544,9 +544,11 @@ namespace Rakugaki {
 			);
 		}
 		construct {
-			var save = add_button (_("Save"), Gtk.ResponseType.OK);
 			var cws = add_button (_("Close Without Saving"), Gtk.ResponseType.NO);
+			cws.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 			var cancel = add_button (_("Cancel"), Gtk.ResponseType.CANCEL) as Gtk.Button;
+			var save = add_button (_("Save"), Gtk.ResponseType.OK);
+			save.has_focus = true;
 			cancel.clicked.connect (() => { destroy (); });
 		}
 	}


### PR DESCRIPTION
We might want to use the dialog style written in elementary HIG so that we can offer a consistent operation for users.

## Changes Summary
* Change buttons order
* Add the "destructive" style to "Close Without Saving" button

## BEFORE
![Screenshot from 2020-01-30 07-56-42](https://user-images.githubusercontent.com/26003928/73404952-16eac100-4336-11ea-95e1-c87aee0a4d3d.png)

## AFTER
![Screenshot from 2020-01-30 07-55-29](https://user-images.githubusercontent.com/26003928/73404951-16eac100-4336-11ea-837e-3cdb4aa61520.png)

## Dialog in Code (as a comparsion)
![Screenshot from 2020-01-30 07-38-09](https://user-images.githubusercontent.com/26003928/73404950-16eac100-4336-11ea-9c99-c0a55975279c.png)
